### PR TITLE
removed jw player entitlements url

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -6581,9 +6581,6 @@
 # [justservingfiles.net]
 127.0.0.1 bmedia.justservingfiles.net
 
-# [jwplayer.com]
-127.0.0.1 entitlements.jwplayer.com
-
 # [jwpsrv.com]
 127.0.0.1 g.jwpsrv.com
 


### PR DESCRIPTION
The domain that was listed "127.0.0.1 entitlements.jwplayer.com" does not serve ads, and blocking it would actually enable ads to play when they should not